### PR TITLE
feat: add ability to cycle preset widths in reverse

### DIFF
--- a/src/lib/behavior/PresetWidths.ts
+++ b/src/lib/behavior/PresetWidths.ts
@@ -11,6 +11,12 @@ class PresetWidths {
         return nextIndex >= 0 ? widths[nextIndex] : widths[0];
     }
 
+    public prev(currentWidth: number, minWidth: number, maxWidth: number) {
+        const widths = this.getWidths(minWidth, maxWidth).reverse();
+        const nextIndex = widths.findIndex(width => width < currentWidth);
+        return nextIndex >= 0 ? widths[nextIndex] : widths[0];
+    }
+
     public getWidths(minWidth: number, maxWidth: number) {
         const widths = this.presets.map(f => clamp(f(maxWidth), minWidth, maxWidth));
         widths.sort((a, b) => a - b);

--- a/src/lib/keyBindings/Actions.ts
+++ b/src/lib/keyBindings/Actions.ts
@@ -189,6 +189,11 @@ class Actions {
         column.setWidth(nextWidth, true);
     }
 
+    public readonly cyclePresetWidthsReverse = (cm: ClientManager, dm: DesktopManager, window: Window, column: Column, grid: Grid) => {
+        const nextWidth = this.config.presetWidths.prev(column.getWidth(), column.getMinWidth(), column.getMaxWidth());
+        column.setWidth(nextWidth, true);
+    }
+
     public readonly columnsWidthEqualize = (cm: ClientManager, dm: DesktopManager) => {
         const desktop = dm.getCurrentDesktop();
         const visibleRange = desktop.getCurrentVisibleRange();
@@ -410,7 +415,10 @@ class Actions {
 namespace Actions {
     export type Config = {
         manualScrollStep: number;
-        presetWidths: { next: (currentWidth: number, minWidth: number, maxWidth: number) => number };
+        presetWidths: {
+            next: (currentWidth: number, minWidth: number, maxWidth: number) => number;
+            prev: (currentWidth: number, minWidth: number, maxWidth: number) => number
+};
         columnResizer: ColumnResizer;
     };
 

--- a/src/lib/keyBindings/definition.ts
+++ b/src/lib/keyBindings/definition.ts
@@ -153,6 +153,12 @@ function getKeyBindings(world: World, actions: Actions): KeyBinding[] {
             action: () => world.doIfTiledFocused(actions.cyclePresetWidths),
         },
         {
+            name: "cycle-preset-widths-reverse",
+            description: "Cycle through preset column widths in reverse",
+            defaultKeySequence: "Meta+Shift+R",
+            action: () => world.doIfTiledFocused(actions.cyclePresetWidthsReverse),
+        },
+        {
             name: "columns-width-equalize",
             description: "Equalize widths of visible columns",
             defaultKeySequence: "Meta+Ctrl+X",

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -11,6 +11,7 @@ class World {
 
         let presetWidths = {
             next: (currentWidth: number, minWidth: number, maxWidth: number) => currentWidth,
+            prev: (currentWidth: number, minWidth: number, maxWidth: number) => currentWidth,
             getWidths: (minWidth: number, maxWidth: number): number[] => [],
         };
         try {

--- a/src/tests/flows/presetWidths.ts
+++ b/src/tests/flows/presetWidths.ts
@@ -25,6 +25,12 @@ tests.register("Preset Widths default", 1, () => {
 
     qtMock.fireShortcut("karousel-cycle-preset-widths");
     Assert.equalRects(kwinClient.frameGeometry, getRect(halfWidth));
+
+    qtMock.fireShortcut("karousel-cycle-preset-widths-reverse");
+    Assert.equalRects(kwinClient.frameGeometry, getRect(maxWidth));
+
+    qtMock.fireShortcut("karousel-cycle-preset-widths-reverse");
+    Assert.equalRects(kwinClient.frameGeometry, getRect(halfWidth));
 });
 
 tests.register("Preset Widths custom", 1, () => {
@@ -61,6 +67,15 @@ tests.register("Preset Widths custom", 1, () => {
 
     qtMock.fireShortcut("karousel-cycle-preset-widths");
     Assert.equalRects(kwinClient.frameGeometry, getRect(250));
+
+    qtMock.fireShortcut("karousel-cycle-preset-widths-reverse");
+    Assert.equalRects(kwinClient.frameGeometry, getRect(100));
+
+    qtMock.fireShortcut("karousel-cycle-preset-widths-reverse");
+    Assert.equalRects(kwinClient.frameGeometry, getRect(500));
+
+    qtMock.fireShortcut("karousel-cycle-preset-widths-reverse");
+    Assert.equalRects(kwinClient.frameGeometry, getRect(halfWidth));
 });
 
 tests.register("Preset Widths fill screen uniform", 1, () => {


### PR DESCRIPTION
Addresses #74 
### Changes
- Added `prev` method to PresetWidths to find the last index of a width smaller than the current width.
- Copied `cyclePresetWidths` to create `cyclePresetWidthsReverse` which calls `prev` instead of `next` on the `PresetWidths` object.
- Added a keybinding definition `cycle-preset-widths-reverse` to call the aforementioned function.
