### PR TITLE
feat: wayland touchpad gestures

### DIFF
--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -110,7 +110,10 @@
                                         <item>
                                             <widget class="QCheckBox" name="kcfg_touchpadGestures">
                                                 <property name="text">
-                                                    <string>Enable touchpad gestures</string>
+                                                    <string>Enable scrolling with touchpad gestures</string>
+                                                </property>
+                                                <property name="toolTip">
+                                                    <string>Scroll with a three-finger horizontal swipe gesture</string>
                                                 </property>
                                             </widget>
                                         </item>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -108,6 +108,14 @@
                                     </property>
                                     <layout class="QVBoxLayout">
                                         <item>
+                                            <widget class="QCheckBox" name="kcfg_touchpadGestures">
+                                                <property name="text">
+                                                    <string>Enable touchpad gestures</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+
+                                        <item>
                                             <widget class="QCheckBox" name="kcfg_naturalScrolling">
                                                 <property name="text">
                                                     <string>Invert scroll direction (Natural scrolling)</string>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -108,9 +108,9 @@
                                     </property>
                                     <layout class="QVBoxLayout">
                                         <item>
-                                            <widget class="QRadioButton" name="kcfg_naturalScrolling">
+                                            <widget class="QCheckBox" name="kcfg_naturalScrolling">
                                                 <property name="text">
-                                                    <string>Natural scrolling: scroll the contents instead of the view</string>
+                                                    <string>Invert scroll direction (Natural scrolling)</string>
                                                 </property>
                                             </widget>
                                         </item>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -408,6 +408,37 @@
                                     </property>
                                 </widget>
                             </item>
+
+                            <item row="11" column="0">
+                                <widget class="QLabel" name="label_gestureScrollStep">
+                                    <property name="text">
+                                        <string>Touchpad gesture scrolling speed:</string>
+                                    </property>
+                                    <property name="toolTip">
+                                        <string>The amount to scroll per edge-to-edge gesture</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="11" column="1">
+                                <widget class="QSpinBox" name="kcfg_gestureScrollStep">
+                                    <property name="suffix">
+                                        <string> px</string>
+                                    </property>
+                                    <property name="maximum">
+                                        <number>10000</number>
+                                    </property>
+                                    <property name="minimum">
+                                        <number>100</number>
+                                    </property>
+                                    <property name="singleStep">
+                                        <number>100</number>
+                                    </property>
+                                    <property name="value">
+                                        <number>1920</number>
+                                    </property>
+                                </widget>
+                            </item>
+
                         </layout>
                     </widget>
 

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -104,6 +104,23 @@
                             <item>
                                 <widget class="QGroupBox">
                                     <property name="title">
+                                        <string>Touchpad scrolling (Wayland only)</string>
+                                    </property>
+                                    <layout class="QVBoxLayout">
+                                        <item>
+                                            <widget class="QRadioButton" name="kcfg_naturalScrolling">
+                                                <property name="text">
+                                                    <string>Natural scrolling: scroll the contents instead of the view</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                    </layout>
+                                </widget>
+                            </item>
+
+                            <item>
+                                <widget class="QGroupBox">
+                                    <property name="title">
                                         <string>Layering mode</string>
                                     </property>
                                     <layout class="QVBoxLayout">

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -108,7 +108,7 @@
                                     </property>
                                     <layout class="QVBoxLayout">
                                         <item>
-                                            <widget class="QCheckBox" name="kcfg_touchpadGestures">
+                                            <widget class="QCheckBox" name="kcfg_gestureScroll">
                                                 <property name="text">
                                                     <string>Enable scrolling with touchpad gestures</string>
                                                 </property>
@@ -119,7 +119,7 @@
                                         </item>
 
                                         <item>
-                                            <widget class="QCheckBox" name="kcfg_naturalScrolling">
+                                            <widget class="QCheckBox" name="kcfg_gestureScrollInvert">
                                                 <property name="text">
                                                     <string>Invert scroll direction (Natural scrolling)</string>
                                                 </property>

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -39,17 +39,17 @@ Item {
     SwipeGestureHandler {
         direction: SwipeGestureHandler.Direction.Left
         fingerCount: 3
-        onActivated: qmlBase.karouselInstance.finishGesture()
-        onCancelled: qmlBase.karouselInstance.finishGesture()
-        onProgressChanged: qmlBase.karouselInstance.doGesture(-progress)
+        onActivated: qmlBase.karouselInstance.gestureScrollFinish()
+        onCancelled: qmlBase.karouselInstance.gestureScrollFinish()
+        onProgressChanged: qmlBase.karouselInstance.gestureScroll(-progress)
     }
 
     SwipeGestureHandler {
         direction: SwipeGestureHandler.Direction.Right
         fingerCount: 3
-        onActivated: qmlBase.karouselInstance.finishGesture()
-        onCancelled: qmlBase.karouselInstance.finishGesture()
-        onProgressChanged: qmlBase.karouselInstance.doGesture(progress)
+        onActivated: qmlBase.karouselInstance.gestureScrollFinish()
+        onCancelled: qmlBase.karouselInstance.gestureScrollFinish()
+        onProgressChanged: qmlBase.karouselInstance.gestureScroll(progress)
     }
 
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -39,17 +39,17 @@ Item {
     SwipeGestureHandler {
         direction: SwipeGestureHandler.Direction.Left
         fingerCount: 3
-        onActivated: qmlBase.karouselInstance.clearScrollX()
-        onCancelled: qmlBase.karouselInstance.clearScrollX()
-        onProgressChanged: qmlBase.karouselInstance.performGesture(-progress)
+        onActivated: qmlBase.karouselInstance.finishGesture()
+        onCancelled: qmlBase.karouselInstance.finishGesture()
+        onProgressChanged: qmlBase.karouselInstance.doGesture(-progress)
     }
 
     SwipeGestureHandler {
         direction: SwipeGestureHandler.Direction.Right
         fingerCount: 3
-        onActivated: qmlBase.karouselInstance.clearScrollX()
-        onCancelled: qmlBase.karouselInstance.clearScrollX()
-        onProgressChanged: qmlBase.karouselInstance.performGesture(progress)
+        onActivated: qmlBase.karouselInstance.finishGesture()
+        onCancelled: qmlBase.karouselInstance.finishGesture()
+        onProgressChanged: qmlBase.karouselInstance.doGesture(progress)
     }
 
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -35,4 +35,21 @@ Item {
         flags: Notification.Persistent
         urgency: Notification.HighUrgency
     }
+
+    SwipeGestureHandler {
+        direction: SwipeGestureHandler.Direction.Left
+        fingerCount: 3
+        onActivated: qmlBase.karouselInstance.clearScrollX()
+        onCancelled: qmlBase.karouselInstance.clearScrollX()
+        onProgressChanged: qmlBase.karouselInstance.performGesture(-progress)
+    }
+
+    SwipeGestureHandler {
+        direction: SwipeGestureHandler.Direction.Right
+        fingerCount: 3
+        onActivated: qmlBase.karouselInstance.clearScrollX()
+        onCancelled: qmlBase.karouselInstance.clearScrollX()
+        onProgressChanged: qmlBase.karouselInstance.performGesture(progress)
+    }
+
 }

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -18,8 +18,8 @@ type Config = {
     scrollingLazy: boolean;
     scrollingCentered: boolean;
     scrollingGrouped: boolean;
-    tiledKeepBelow: boolean;
     naturalScrolling: boolean;
+    tiledKeepBelow: boolean;
     floatingKeepAbove: boolean;
     windowRules: string;
 };

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -10,6 +10,7 @@ type Config = {
     manualScrollStep: number;
     presetWidths: string;
     offScreenOpacity: number;
+    gestureScrollStep: number;
     untileOnDrag: boolean;
     stackColumnsByDefault: boolean;
     resizeNeighborColumn: boolean;

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -19,6 +19,7 @@ type Config = {
     scrollingCentered: boolean;
     scrollingGrouped: boolean;
     tiledKeepBelow: boolean;
+    naturalScrolling: boolean;
     floatingKeepAbove: boolean;
     windowRules: string;
 };

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -19,8 +19,8 @@ type Config = {
     scrollingLazy: boolean;
     scrollingCentered: boolean;
     scrollingGrouped: boolean;
-    touchpadGestures: boolean;
-    naturalScrolling: boolean;
+    gestureScroll: boolean;
+    gestureScrollInvert: boolean;
     tiledKeepBelow: boolean;
     floatingKeepAbove: boolean;
     windowRules: string;

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -18,6 +18,7 @@ type Config = {
     scrollingLazy: boolean;
     scrollingCentered: boolean;
     scrollingGrouped: boolean;
+    touchpadGestures: boolean;
     naturalScrolling: boolean;
     tiledKeepBelow: boolean;
     floatingKeepAbove: boolean;

--- a/src/lib/config/definition.ts
+++ b/src/lib/config/definition.ts
@@ -155,6 +155,11 @@ const configDef = [
         default: true,
     },
     {
+        name: "naturalScrolling",
+        type: "Bool",
+        default: true,
+    },
+    {
         name: "floatingKeepAbove",
         type: "Bool",
         default: false,

--- a/src/lib/config/definition.ts
+++ b/src/lib/config/definition.ts
@@ -150,14 +150,14 @@ const configDef = [
         default: false,
     },
     {
-        name: "tiledKeepBelow",
-        type: "Bool",
-        default: true,
-    },
-    {
         name: "naturalScrolling",
         type: "Bool",
         default: false,
+    },
+    {
+        name: "tiledKeepBelow",
+        type: "Bool",
+        default: true,
     },
     {
         name: "floatingKeepAbove",

--- a/src/lib/config/definition.ts
+++ b/src/lib/config/definition.ts
@@ -157,7 +157,7 @@ const configDef = [
     {
         name: "naturalScrolling",
         type: "Bool",
-        default: true,
+        default: false,
     },
     {
         name: "floatingKeepAbove",

--- a/src/lib/config/definition.ts
+++ b/src/lib/config/definition.ts
@@ -155,12 +155,12 @@ const configDef = [
         default: false,
     },
     {
-        name: "touchpadGestures",
+        name: "gestureScroll",
         type: "Bool",
         default: false,
     },
     {
-        name: "naturalScrolling",
+        name: "gestureScrollInvert",
         type: "Bool",
         default: false,
     },

--- a/src/lib/config/definition.ts
+++ b/src/lib/config/definition.ts
@@ -110,6 +110,11 @@ const configDef = [
         default: 100,
     },
     {
+        name: "gestureScrollStep",
+        type: "UInt",
+        default: 1920,
+    },
+    {
         name: "untileOnDrag",
         type: "Bool",
         default: true,

--- a/src/lib/config/definition.ts
+++ b/src/lib/config/definition.ts
@@ -150,6 +150,11 @@ const configDef = [
         default: false,
     },
     {
+        name: "touchpadGestures",
+        type: "Bool",
+        default: false,
+    },
+    {
         name: "naturalScrolling",
         type: "Bool",
         default: false,

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -127,6 +127,9 @@ class Desktop {
     }
 
     public gestureScroll(progress: number) {
+        if (!this.config.touchpadGestures) {
+            return
+        }
         if (this.gestureInitialScrollX === null) {
             this.gestureInitialScrollX = this.scrollX;
         }
@@ -178,6 +181,7 @@ namespace Desktop {
         marginBottom: number;
         marginLeft: number;
         marginRight: number;
+        touchpadGestures: boolean;
         naturalScrolling: boolean;
         scroller: Desktop.Scroller;
         clamper: Desktop.Clamper;

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -2,6 +2,7 @@ class Desktop {
     public readonly grid: Grid;
     private scrollX: number;
     private phantomScrollX: number | null;
+    private naturalScrolling: boolean;
     private dirty: boolean;
     private dirtyScroll: boolean;
     private dirtyPins: boolean;
@@ -23,6 +24,7 @@ class Desktop {
         this.grid = new Grid(this, layoutConfig);
         this.clientArea = Desktop.getClientArea(this.getScreen(), kwinDesktop);
         this.tilingArea = Desktop.getTilingArea(this.clientArea, kwinDesktop, pinManager, config);
+        this.naturalScrolling = config.naturalScrolling;
     }
 
     private updateArea() {
@@ -130,6 +132,10 @@ class Desktop {
         if (this.phantomScrollX === null) {
             this.phantomScrollX = this.scrollX;
         }
+
+        if (this.naturalScrolling) {
+            progress = -progress;
+        }
         this.setScroll(this.phantomScrollX + this.clientArea.width * progress, false);
         this.arrange();
     }
@@ -174,6 +180,7 @@ namespace Desktop {
         marginBottom: number;
         marginLeft: number;
         marginRight: number;
+        naturalScrolling: boolean;
         scroller: Desktop.Scroller;
         clamper: Desktop.Clamper;
     };

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -137,7 +137,7 @@ class Desktop {
         if (this.config.naturalScrolling) {
             progress = -progress;
         }
-        this.setScroll(this.gestureInitialScrollX + this.clientArea.width * progress, false);
+        this.setScroll(this.gestureInitialScrollX + this.config.gestureScrollStep * progress, false);
         this.arrange();
     }
 
@@ -182,6 +182,7 @@ namespace Desktop {
         marginLeft: number;
         marginRight: number;
         touchpadGestures: boolean;
+        gestureScrollStep: number;
         naturalScrolling: boolean;
         scroller: Desktop.Scroller;
         clamper: Desktop.Clamper;

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -124,6 +124,10 @@ class Desktop {
         this.setScroll(this.scrollX + dx, force);
     }
 
+    public getScroll(): number {
+        return this.scrollX
+    }
+
     public arrange() {
         // TODO (optimization): only arrange visible windows
         this.updateArea();

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -2,7 +2,6 @@ class Desktop {
     public readonly grid: Grid;
     private scrollX: number;
     private phantomScrollX: number | null;
-    private naturalScrolling: boolean;
     private dirty: boolean;
     private dirtyScroll: boolean;
     private dirtyPins: boolean;
@@ -24,7 +23,6 @@ class Desktop {
         this.grid = new Grid(this, layoutConfig);
         this.clientArea = Desktop.getClientArea(this.getScreen(), kwinDesktop);
         this.tilingArea = Desktop.getTilingArea(this.clientArea, kwinDesktop, pinManager, config);
-        this.naturalScrolling = config.naturalScrolling;
     }
 
     private updateArea() {
@@ -133,7 +131,7 @@ class Desktop {
             this.phantomScrollX = this.scrollX;
         }
 
-        if (this.naturalScrolling) {
+        if (this.config.naturalScrolling) {
             progress = -progress;
         }
         this.setScroll(this.phantomScrollX + this.clientArea.width * progress, false);

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -1,7 +1,7 @@
 class Desktop {
     public readonly grid: Grid;
     private scrollX: number;
-    private phantomScrollX: number | null;
+    private gestureInitialScrollX: number | null;
     private dirty: boolean;
     private dirtyScroll: boolean;
     private dirtyPins: boolean;
@@ -16,7 +16,7 @@ class Desktop {
         layoutConfig: LayoutConfig,
     ) {
         this.scrollX = 0;
-        this.phantomScrollX = null;
+        this.gestureInitialScrollX = null;
         this.dirty = true;
         this.dirtyScroll = true;
         this.dirtyPins = true;
@@ -127,19 +127,19 @@ class Desktop {
     }
 
     public gestureScroll(progress: number) {
-        if (this.phantomScrollX === null) {
-            this.phantomScrollX = this.scrollX;
+        if (this.gestureInitialScrollX === null) {
+            this.gestureInitialScrollX = this.scrollX;
         }
 
         if (this.config.naturalScrolling) {
             progress = -progress;
         }
-        this.setScroll(this.phantomScrollX + this.clientArea.width * progress, false);
+        this.setScroll(this.gestureInitialScrollX + this.clientArea.width * progress, false);
         this.arrange();
     }
 
     public finishGesture() {
-        this.phantomScrollX = null;
+        this.gestureInitialScrollX = null;
     }
 
     public arrange() {

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -1,6 +1,7 @@
 class Desktop {
     public readonly grid: Grid;
     private scrollX: number;
+    private phantomScrollX: number | null;
     private dirty: boolean;
     private dirtyScroll: boolean;
     private dirtyPins: boolean;
@@ -15,6 +16,7 @@ class Desktop {
         layoutConfig: LayoutConfig,
     ) {
         this.scrollX = 0;
+        this.phantomScrollX = null;
         this.dirty = true;
         this.dirtyScroll = true;
         this.dirtyPins = true;
@@ -124,8 +126,16 @@ class Desktop {
         this.setScroll(this.scrollX + dx, force);
     }
 
-    public getScroll(): number {
-        return this.scrollX
+    public gestureScroll(progress: number) {
+        if (this.phantomScrollX === null) {
+            this.phantomScrollX = this.scrollX;
+        }
+        this.setScroll(this.phantomScrollX + this.clientArea.width * progress, false);
+        this.arrange();
+    }
+
+    public finishGesture() {
+        this.phantomScrollX = null;
     }
 
     public arrange() {

--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -126,22 +126,21 @@ class Desktop {
         this.setScroll(this.scrollX + dx, force);
     }
 
-    public gestureScroll(progress: number) {
-        if (!this.config.touchpadGestures) {
+    public gestureScroll(amount: number) {
+        if (!this.config.gestureScroll) {
             return
         }
         if (this.gestureInitialScrollX === null) {
             this.gestureInitialScrollX = this.scrollX;
         }
 
-        if (this.config.naturalScrolling) {
-            progress = -progress;
+        if (this.config.gestureScrollInvert) {
+            amount = -amount;
         }
-        this.setScroll(this.gestureInitialScrollX + this.config.gestureScrollStep * progress, false);
-        this.arrange();
+        this.setScroll(this.gestureInitialScrollX + this.config.gestureScrollStep * amount, false);
     }
 
-    public finishGesture() {
+    public gestureScrollFinish() {
         this.gestureInitialScrollX = null;
     }
 
@@ -181,9 +180,9 @@ namespace Desktop {
         marginBottom: number;
         marginLeft: number;
         marginRight: number;
-        touchpadGestures: boolean;
+        gestureScroll: boolean;
         gestureScrollStep: number;
-        naturalScrolling: boolean;
+        gestureScrollInvert: boolean;
         scroller: Desktop.Scroller;
         clamper: Desktop.Clamper;
     };

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -63,6 +63,7 @@ class World {
                 clamper: config.scrollingLazy ? new EdgeClamper() : new CenterClamper(),
                 naturalScrolling: config.naturalScrolling,
                 touchpadGestures: config.touchpadGestures,
+                gestureScrollStep: config.gestureScrollStep,
             },
             layoutConfig,
             Workspace.currentActivity,

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -62,6 +62,7 @@ class World {
                 scroller: World.createScroller(config),
                 clamper: config.scrollingLazy ? new EdgeClamper() : new CenterClamper(),
                 naturalScrolling: config.naturalScrolling,
+                touchpadGestures: config.touchpadGestures,
             },
             layoutConfig,
             Workspace.currentActivity,

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -61,8 +61,8 @@ class World {
                 marginRight: config.gapsOuterRight,
                 scroller: World.createScroller(config),
                 clamper: config.scrollingLazy ? new EdgeClamper() : new CenterClamper(),
-                naturalScrolling: config.naturalScrolling,
-                touchpadGestures: config.touchpadGestures,
+                gestureScroll: config.gestureScroll,
+                gestureScrollInvert: config.gestureScrollInvert,
                 gestureScrollStep: config.gestureScrollStep,
             },
             layoutConfig,
@@ -99,12 +99,12 @@ class World {
         this.desktopManager.getCurrentDesktop().arrange();
     }
 
-    public doGesture(progress: number) {
-        this.desktopManager.getCurrentDesktop().gestureScroll(progress);
+    public gestureScroll(amount: number) {
+        this.do((clientManager, desktopManager) => desktopManager.getCurrentDesktop().gestureScroll(amount));
     }
 
-    public finishGesture() {
-        this.desktopManager.getCurrentDesktop().finishGesture();
+    public gestureScrollFinish() {
+        this.do((clientManager, desktopManager) => desktopManager.getCurrentDesktop().gestureScrollFinish());
     }
 
     public do(f: (clientManager: ClientManager, desktopManager: DesktopManager) => void) {

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -5,11 +5,9 @@ class World {
     private readonly workspaceSignalManager: SignalManager;
     private readonly shortcutActions: ShortcutAction[];
     private readonly screenResizedDelayer: Delayer;
-    private scrollX: number | null;
 
     constructor(config: Config) {
         this.workspaceSignalManager = initWorkspaceSignalHandlers(this);
-        this.scrollX = null;
 
         let presetWidths = {
             next: (currentWidth: number, minWidth: number, maxWidth: number) => currentWidth,

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -98,17 +98,12 @@ class World {
         this.desktopManager.getCurrentDesktop().arrange();
     }
 
-    public performGesture(progress: number) {
-        let desktop = this.desktopManager.getCurrentDesktop();
-        if (this.scrollX === null) {
-            this.scrollX = desktop.getScroll()
-        }
-        desktop.setScroll(this.scrollX + desktop.clientArea.width * progress, false);
-        this.update();
+    public doGesture(progress: number) {
+        this.desktopManager.getCurrentDesktop().gestureScroll(progress);
     }
 
-    public clearScrollX() {
-        this.scrollX = null
+    public finishGesture() {
+        this.desktopManager.getCurrentDesktop().finishGesture();
     }
 
     public do(f: (clientManager: ClientManager, desktopManager: DesktopManager) => void) {

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -5,9 +5,11 @@ class World {
     private readonly workspaceSignalManager: SignalManager;
     private readonly shortcutActions: ShortcutAction[];
     private readonly screenResizedDelayer: Delayer;
+    private scrollX: number | null;
 
     constructor(config: Config) {
         this.workspaceSignalManager = initWorkspaceSignalHandlers(this);
+        this.scrollX = null;
 
         let presetWidths = {
             next: (currentWidth: number, minWidth: number, maxWidth: number) => currentWidth,
@@ -94,6 +96,19 @@ class World {
 
     private update() {
         this.desktopManager.getCurrentDesktop().arrange();
+    }
+
+    public performGesture(progress: number) {
+        let desktop = this.desktopManager.getCurrentDesktop();
+        if (this.scrollX === null) {
+            this.scrollX = desktop.getScroll()
+        }
+        desktop.setScroll(this.scrollX + desktop.clientArea.width * progress, false);
+        this.update();
+    }
+
+    public clearScrollX() {
+        this.scrollX = null
     }
 
     public do(f: (clientManager: ClientManager, desktopManager: DesktopManager) => void) {

--- a/src/lib/world/World.ts
+++ b/src/lib/world/World.ts
@@ -63,6 +63,7 @@ class World {
                 marginRight: config.gapsOuterRight,
                 scroller: World.createScroller(config),
                 clamper: config.scrollingLazy ? new EdgeClamper() : new CenterClamper(),
+                naturalScrolling: config.naturalScrolling,
             },
             layoutConfig,
             Workspace.currentActivity,


### PR DESCRIPTION
Addresses #5 

### Changes
- Creates QML objects in main.qml that emit SwipeGesture signals.
- Adds methods to the Desktop class to begin and finish a gesture.
- Adds `phantomScrollX` attribute to `Desktop` that temporarily holds the last `scrollX` value before a gesture began. This old value serves as a frame of reference during the progression of the gesture.
- Adds `naturalScrolling` attribute to `Desktop.Config` and `Config` to flip scroll direction.
- Adds UI options to toggle natural scrolling.
