### PR TITLE
Change focus on scroll with gesture

### DIFF
--- a/src/lib/layout/Desktop.ts
+++ b/src/lib/layout/Desktop.ts
@@ -143,6 +143,21 @@ class Desktop {
 
     public gestureScrollFinish() {
         this.gestureScrollXInitial = null;
+
+        const visibleRange = this.grid.desktop.getCurrentVisibleRange();
+
+        const focusedColumn = this.grid.getLastFocusedColumn();
+        if (focusedColumn !== null) {
+            if (Range.contains(visibleRange, focusedColumn)) {
+                return;
+            }
+        }
+
+        const currentVisibleColumns = Array.from(this.grid.getVisibleColumns(visibleRange, false));
+
+        if (currentVisibleColumns.length != 0) {
+            currentVisibleColumns[0].getFirstWindow().focus();
+        }
     }
 
     public arrange() {


### PR DESCRIPTION
This patch makes it so that when you scroll with touchpad gestures, it focuses the currently visible window at the end of the gesture.

Fixes #107