### PR TITLE
Change window-stacking direction to from top-right to bottom-left

### DIFF
--- a/src/lib/layout/Column.ts
+++ b/src/lib/layout/Column.ts
@@ -231,11 +231,11 @@ class Column {
         const windowWidth = this.width - (nWindows - 1) * this.grid.config.stackOffsetX;
         const windowHeight = this.grid.desktop.tilingArea.height - (nWindows - 1) * this.grid.config.stackOffsetY;
 
-        let windowX = x;
+        let windowX = x + (nWindows - 1) * this.grid.config.stackOffsetX;
         let windowY = this.grid.desktop.tilingArea.y;
         for (const window of this.windows.iterator()) {
             window.arrange(windowX, windowY, windowWidth, windowHeight);
-            windowX += this.grid.config.stackOffsetX;
+            windowX -= this.grid.config.stackOffsetX;
             windowY += this.grid.config.stackOffsetY;
         }
     }

--- a/src/tests/utils/Assert.ts
+++ b/src/tests/utils/Assert.ts
@@ -190,7 +190,7 @@ namespace Assert {
         function getRectInGridStacked(column: number, window: number, nColumns: number, nWindows: number) {
             const columnWidth = getColumnWidth(column);
             return new MockQmlRect(
-                getColumnX(column) + window * config.stackOffsetX,
+                getColumnX(column) + (nWindows-window-1) * config.stackOffsetX,
                 tilingArea.y + window * config.stackOffsetY,
                 columnWidth - (nWindows-1) * config.stackOffsetX,
                 tilingArea.height - (nWindows-1) * config.stackOffsetY,


### PR DESCRIPTION
This is how windows are traditionally stacked (e.g. from Windows 3.1 era).