### PR TITLE
Fix "Decrease column width" requires two keypresses through certain p…

### DIFF
--- a/src/lib/behavior/columnResizer/ContextualResizer.ts
+++ b/src/lib/behavior/columnResizer/ContextualResizer.ts
@@ -3,6 +3,8 @@ class ContextualResizer {
         private readonly presetWidths: { getWidths: (minWidth: number, maxWidth: number) => number[] },
     ) {}
 
+    private readonly DELTA = 1;
+
     public increaseWidth(column: Column) {
         const grid = column.grid;
         const desktop = grid.desktop;
@@ -30,7 +32,7 @@ class ContextualResizer {
                 column.getWidth() + leftSpace + rightSpace + rightVisibleColumn.getWidth() + grid.config.gapsInnerHorizontal,
                 ...this.presetWidths.getWidths(minWidth, maxWidth),
             ],
-            width => width - column.getWidth(),
+            width => width - column.getWidth() - this.DELTA,
         );
         if (newWidth === undefined) {
             return;
@@ -77,7 +79,7 @@ class ContextualResizer {
                 column.getWidth() - rightOffScreen,
                 ...this.presetWidths.getWidths(minWidth, maxWidth),
             ],
-            width => column.getWidth() - width,
+            width => column.getWidth() - width - this.DELTA,
         );
         if (newWidth === undefined) {
             return;

--- a/src/lib/behavior/columnResizer/RawResizer.ts
+++ b/src/lib/behavior/columnResizer/RawResizer.ts
@@ -3,16 +3,19 @@ class RawResizer {
         private readonly presetWidths: { getWidths: (minWidth: number, maxWidth: number) => number[] },
     ) {}
 
+    private readonly DELTA = 1;
+
     public increaseWidth(column: Column) {
         const newWidth = findMinPositive(
             [
                 ...this.presetWidths.getWidths(column.getMinWidth(), column.getMaxWidth()),
             ],
-            width => width - column.getWidth(),
+            width => width - column.getWidth() - this.DELTA,
         );
         if (newWidth === undefined) {
             return;
         }
+
         column.setWidth(newWidth, true);
     }
 
@@ -21,11 +24,12 @@ class RawResizer {
             [
                 ...this.presetWidths.getWidths(column.getMinWidth(), column.getMaxWidth()),
             ],
-            width => column.getWidth() - width,
+            width => column.getWidth() - width - this.DELTA,
         );
         if (newWidth === undefined) {
             return;
         }
+
         column.setWidth(newWidth, true);
     }
 }


### PR DESCRIPTION
…reset width in fractional scaling

Kwin might adjust the logical window width to a fractional number, so it lands at integer physical pixels. (E.g. from 939 to 939.2 at 2.5x scaling, so we would again try to decrease width from 939.2 to 939, with no visible effect).

Fixed by requiring new width to be at lease 1px different from the current one.

BUG: #151