### PR TITLE
added tips for layering modes

### DIFF
--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -149,55 +149,34 @@
                                         <item>
                                             <widget class="QRadioButton" name="kcfg_tiledKeepBelow">
                                                 <property name="text">
-                                                    <string>Keep tiled windows below</string>
+                                                    <string>Set Keep Below for tiled windows</string>
                                                 </property>
                                             </widget>
-                                        </item>
-                                        <item>
-                                            <layout class="QHBoxLayout">
-                                                <item>
-                                                    <widget class="QLabel">
-                                                        <property name="text">
-                                                            <string>Tiled windows use KWin's "Keep Below" property; floating windows stay at normal stacking</string>
-                                                        </property>
-                                                        <property name="wordWrap">
-                                                            <bool>true</bool>
-                                                        </property>
-                                                        <property name="enabled">
-                                                            <bool>false</bool>
-                                                        </property>
-                                                    </widget>
-                                                </item>
-                                            </layout>
                                         </item>
                                         <item>
                                             <widget class="QRadioButton" name="kcfg_floatingKeepAbove">
                                                 <property name="text">
-                                                    <string>Keep floating windows above</string>
+                                                    <string>Set Keep Above for floating windows</string>
                                                 </property>
                                             </widget>
-                                        </item>
-                                        <item>
-                                            <layout class="QHBoxLayout">
-                                                <item>
-                                                    <widget class="QLabel">
-                                                        <property name="text">
-                                                            <string>Floating windows use KWin's native "Keep Above Others" (always-on-top). This may also trigger KWin window rules and other settings bound to the keep-above state.</string>
-                                                        </property>
-                                                        <property name="wordWrap">
-                                                            <bool>true</bool>
-                                                        </property>
-                                                        <property name="enabled">
-                                                            <bool>false</bool>
-                                                        </property>
-                                                    </widget>
-                                                </item>
-                                            </layout>
                                         </item>
                                         <item>
                                             <widget class="QRadioButton" name="kcfg_noLayering">
                                                 <property name="text">
                                                     <string>No layering</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="QLabel">
+                                                <property name="text">
+                                                    <string>Note: KWin window rules bound to Keep Below/Above states will also apply.</string>
+                                                </property>
+                                                <property name="wordWrap">
+                                                    <bool>true</bool>
+                                                </property>
+                                                <property name="enabled">
+                                                    <bool>false</bool>
                                                 </property>
                                             </widget>
                                         </item>


### PR DESCRIPTION
Simple additional tip for layering modes, fixes #155 . 
<img width="522" height="252" alt="image" src="https://github.com/user-attachments/assets/726928c7-8722-495b-b90d-77b4a2191771" />

Please feel free to tweak the language or visuals. Thanks for the great project! 